### PR TITLE
First pass at removing User model requirement.

### DIFF
--- a/payments/management/commands/init_customers.py
+++ b/payments/management/commands/init_customers.py
@@ -1,7 +1,7 @@
 from django.core.management.base import BaseCommand
 
 from ...models import Customer
-from ...utils import get_user_model
+from ...utils import get_ref_model
 
 
 class Command(BaseCommand):
@@ -9,7 +9,7 @@ class Command(BaseCommand):
     help = "Create customer objects for existing users that don't have one"
 
     def handle(self, *args, **options):
-        User = get_user_model()
-        for user in User.objects.filter(customer__isnull=True):
-            Customer.create(user=user)
-            print("Created customer for {0}".format(user.email))
+        Ref = get_ref_model()
+        for ref in Ref.objects.filter(customer__isnull=True):
+            Customer.create(ref=ref)
+            print("Created customer for {0}".format(ref))

--- a/payments/management/commands/sync_customers.py
+++ b/payments/management/commands/sync_customers.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 
-from ...utils import get_user_model
+from ...utils import get_ref_model
 
 
 class Command(BaseCommand):
@@ -8,17 +8,17 @@ class Command(BaseCommand):
     help = "Sync customer data"
 
     def handle(self, *args, **options):
-        User = get_user_model()
-        qs = User.objects.exclude(customer__isnull=True)
+        Ref = get_ref_model()
+        qs = Ref.objects.exclude(customer__isnull=True)
         count = 0
         total = qs.count()
-        for user in qs:
+        for ref in qs:
             count += 1
             perc = int(round(100 * (float(count) / float(total))))
-            print("[{0}/{1} {2}%] Syncing {3} [{4}]".format(
-                count, total, perc, user.username, user.pk
+            print("[{0}/{1} {2}%] Syncing {3}]".format(
+                count, total, perc, ref
             ))
-            customer = user.customer
+            customer = ref.customer
             cu = customer.stripe_customer
             customer.sync(cu=cu)
             customer.sync_current_subscription(cu=cu)

--- a/payments/settings.py
+++ b/payments/settings.py
@@ -41,6 +41,10 @@ if isinstance(PLAN_QUANTITY_CALLBACK, six.string_types):
 
 SEND_EMAIL_RECEIPTS = getattr(settings, "SEND_EMAIL_RECEIPTS", True)
 
+CUSTOMER_REF_MODEL = getattr(settings, "CUSTOMER_REF_MODEL", None)
+
+CUSTOMER_REF_SEARCH_FIELDS = getattr(settings, "CUSTOMER_REF_SEARCH_FIELDS", [])
+
 
 def plan_from_stripe_id(stripe_id):
     for key in PAYMENTS_PLANS.keys():

--- a/payments/tests/test_commands.py
+++ b/payments/tests/test_commands.py
@@ -5,13 +5,13 @@ from django.test import TestCase
 from mock import patch
 
 from ..models import Customer
-from ..utils import get_user_model
+from ..utils import get_ref_model
 
 
 class CommandTests(TestCase):
 
     def setUp(self):
-        User = get_user_model()
+        User = get_ref_model()
         self.user = User.objects.create_user(username="patrick")
 
     @patch("stripe.Customer.retrieve")
@@ -43,10 +43,10 @@ class CommandTests(TestCase):
     @patch("payments.models.Customer.sync_invoices")
     @patch("payments.models.Customer.sync_charges")
     def test_sync_customers(self, SyncChargesMock, SyncInvoicesMock, SyncSubscriptionMock, SyncMock, RetrieveMock):
-        user2 = get_user_model().objects.create_user(username="thomas")
-        get_user_model().objects.create_user(username="altman")
-        Customer.objects.create(stripe_id="cus_XXXXX", user=self.user)
-        Customer.objects.create(stripe_id="cus_YYYYY", user=user2)
+        user2 = get_ref_model().objects.create_user(username="thomas")
+        get_ref_model().objects.create_user(username="altman")
+        Customer.objects.create(stripe_id="cus_XXXXX", ref=self.user)
+        Customer.objects.create(stripe_id="cus_YYYYY", ref=user2)
         management.call_command("sync_customers")
         self.assertEqual(SyncChargesMock.call_count, 2)
         self.assertEqual(SyncInvoicesMock.call_count, 2)

--- a/payments/tests/test_email.py
+++ b/payments/tests/test_email.py
@@ -7,16 +7,16 @@ from django.test import TestCase
 from mock import patch
 
 from ..models import Customer
-from ..utils import get_user_model
+from ..utils import get_ref_model
 
 
 class EmailReceiptTest(TestCase):
 
     def setUp(self):
-        User = get_user_model()
+        User = get_ref_model()
         self.user = User.objects.create_user(username="patrick")
         self.customer = Customer.objects.create(
-            user=self.user,
+            ref=self.user,
             stripe_id="cus_xxxxxxxxxxxxxxx",
             card_fingerprint="YYYYYYYY",
             card_last_4="2342",

--- a/payments/tests/test_event.py
+++ b/payments/tests/test_event.py
@@ -6,17 +6,17 @@ from mock import patch, Mock
 
 from ..models import Customer, Event, CurrentSubscription
 from payments.signals import WEBHOOK_SIGNALS
-from ..utils import get_user_model
+from ..utils import get_ref_model
 
 
 class TestEventMethods(TestCase):
     def setUp(self):
-        User = get_user_model()
+        User = get_ref_model()
         self.user = User.objects.create_user(username="testuser")
         self.user.save()
         self.customer = Customer.objects.create(
             stripe_id="cus_xxxxxxxxxxxxxxx",
-            user=self.user
+            ref=self.user
         )
 
     def test_link_customer_customer_created(self):
@@ -177,7 +177,7 @@ class TestEventMethods(TestCase):
         )
         event.process()
         self.assertEquals(event.customer, self.customer)
-        self.assertEquals(event.customer.user, None)
+        self.assertEquals(event.customer.ref, None)
 
     @staticmethod
     def send_signal(customer, kind):

--- a/payments/tests/test_managers.py
+++ b/payments/tests/test_managers.py
@@ -6,20 +6,20 @@ from django.utils import timezone
 
 from . import TRANSFER_CREATED_TEST_DATA, TRANSFER_CREATED_TEST_DATA2
 from ..models import Event, Transfer, Customer, CurrentSubscription, Charge
-from ..utils import get_user_model
+from ..utils import get_ref_model
 
 
 class CustomerManagerTest(TestCase):
 
     def setUp(self):
-        User = get_user_model()
+        User = get_ref_model()
         # create customers and current subscription records
         period_start = datetime.datetime(2013, 4, 1, tzinfo=timezone.utc)
         period_end = datetime.datetime(2013, 4, 30, tzinfo=timezone.utc)
         start = datetime.datetime(2013, 1, 1, tzinfo=timezone.utc)
         for i in range(10):
             customer = Customer.objects.create(
-                user=User.objects.create_user(username="patrick{0}".format(i)),
+                ref=User.objects.create_user(username="patrick{0}".format(i)),
                 stripe_id="cus_xxxxxxxxxxxxxx{0}".format(i),
                 card_fingerprint="YYYYYYYY",
                 card_last_4="2342",
@@ -36,7 +36,7 @@ class CustomerManagerTest(TestCase):
                 quantity=1
             )
         customer = Customer.objects.create(
-            user=User.objects.create_user(username="patrick{0}".format(11)),
+            ref=User.objects.create_user(username="patrick{0}".format(11)),
             stripe_id="cus_xxxxxxxxxxxxxx{0}".format(11),
             card_fingerprint="YYYYYYYY",
             card_last_4="2342",
@@ -54,7 +54,7 @@ class CustomerManagerTest(TestCase):
             quantity=1
         )
         customer = Customer.objects.create(
-            user=User.objects.create_user(username="patrick{0}".format(12)),
+            ref=User.objects.create_user(username="patrick{0}".format(12)),
             stripe_id="cus_xxxxxxxxxxxxxx{0}".format(12),
             card_fingerprint="YYYYYYYY",
             card_last_4="2342",
@@ -176,7 +176,7 @@ class ChargeManagerTests(TestCase):
 
     def setUp(self):
         customer = Customer.objects.create(
-            user=get_user_model().objects.create_user(username="patrick"),
+            ref=get_ref_model().objects.create_user(username="patrick"),
             stripe_id="cus_xxxxxxxxxxxxxx"
         )
         Charge.objects.create(

--- a/payments/tests/test_middleware.py
+++ b/payments/tests/test_middleware.py
@@ -12,7 +12,7 @@ from mock import Mock
 
 from ..middleware import ActiveSubscriptionMiddleware
 from ..models import Customer, CurrentSubscription
-from ..utils import get_user_model
+from ..utils import get_ref_model
 
 
 class DummySession(dict):
@@ -39,7 +39,7 @@ class ActiveSubscriptionMiddlewareTests(TestCase):
             'password_reset'
         )
 
-        user = get_user_model().objects.create_user(username="patrick")
+        user = get_ref_model().objects.create_user(username="patrick")
         user.set_password("eldarion")
         user.save()
         user = authenticate(username="patrick", password="eldarion")
@@ -68,13 +68,13 @@ class ActiveSubscriptionMiddlewareTests(TestCase):
         self.assertIsNone(response)
 
     def test_authed_user_with_no_active_subscription_passes_with_exempt_url(self):
-        Customer.objects.create(stripe_id="cus_1", user=self.request.user)
+        Customer.objects.create(stripe_id="cus_1", ref=self.request.user)
         self.request.path = "/accounts/signup/"
         response = self.middleware.process_request(self.request)
         self.assertIsNone(response)
 
     def test_authed_user_with_no_active_subscription_redirects_on_non_exempt_url(self):
-        Customer.objects.create(stripe_id="cus_1", user=self.request.user)
+        Customer.objects.create(stripe_id="cus_1", ref=self.request.user)
         self.request.path = "/the/app/"
         response = self.middleware.process_request(self.request)
         self.assertEqual(response.status_code, 302)
@@ -86,7 +86,7 @@ class ActiveSubscriptionMiddlewareTests(TestCase):
     def test_authed_user_with_active_subscription_redirects_on_non_exempt_url(self):
         customer = Customer.objects.create(
             stripe_id="cus_1",
-            user=self.request.user
+            ref=self.request.user
         )
         CurrentSubscription.objects.create(
             customer=customer,

--- a/payments/tests/test_templatetags.py
+++ b/payments/tests/test_templatetags.py
@@ -9,7 +9,7 @@ from mock import Mock
 
 from ..models import CurrentSubscription, Customer
 from ..templatetags.payments_tags import change_plan_form, subscribe_form
-from ..utils import get_user_model
+from ..utils import get_ref_model
 
 from .test_middleware import DummySession
 
@@ -20,12 +20,12 @@ class PaymentsTagTests(TestCase):
         request = Mock()
         request.META = {}
         request.session = DummySession()
-        user = get_user_model().objects.create_user(username="patrick")
+        user = get_ref_model().objects.create_user(username="patrick")
         user.set_password("eldarion")
         user.save()
         customer = Customer.objects.create(
             stripe_id="cus_1",
-            user=user
+            ref=user
         )
         CurrentSubscription.objects.create(
             customer=customer,

--- a/payments/tests/test_views.py
+++ b/payments/tests/test_views.py
@@ -12,7 +12,7 @@ import stripe
 from mock import patch
 
 from ..models import Customer, CurrentSubscription
-from ..utils import get_user_model
+from ..utils import get_ref_model
 from ..views import SubscribeView
 
 
@@ -36,14 +36,14 @@ class AjaxViewsTests(TestCase):
 
     def setUp(self):
         self.password = "eldarion"
-        self.user = get_user_model().objects.create_user(
+        self.user = get_ref_model().objects.create_user(
             username="patrick",
             password=self.password
         )
         self.user.save()
         customer = Customer.objects.create(
             stripe_id="cus_1",
-            user=self.user
+            ref=self.user
         )
         CurrentSubscription.objects.create(
             customer=customer,

--- a/payments/utils.py
+++ b/payments/utils.py
@@ -22,14 +22,18 @@ def convert_tstamp(response, field_name=None):
     return None
 
 
-def get_user_model():  # pragma: no cover
-    try:
-        # pylint: disable=E0611
-        from django.contrib.auth import get_user_model as django_get_user_model
-        return django_get_user_model()
-    except ImportError:
-        from django.contrib.auth.models import User
-        return User
+def get_ref_model():  # pragma: no cover
+    from .settings import CUSTOMER_REF_MODEL
+    if CUSTOMER_REF_MODEL is not None:
+        return load_path_attr(CUSTOMER_REF_MODEL)
+    else:
+        try:
+            # pylint: disable=E0611
+            from django.contrib.auth import get_user_model as django_get_user_model
+            return django_get_user_model()
+        except ImportError:
+            from django.contrib.auth.models import User
+            return User
 
 
 def load_path_attr(path):  # pragma: no cover
@@ -38,7 +42,7 @@ def load_path_attr(path):  # pragma: no cover
     try:
         mod = importlib.import_module(module)
     except ImportError as e:
-        raise ImproperlyConfigured("Error importing {0}: '{1}'".format(module, e))
+        raise ImproperlyConfigured("Error importing {0}.{1}: '{2}'".format(module, attr, e))
     try:
         attr = getattr(mod, attr)
     except AttributeError:

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
     py27-1.6, py27-1.7, py27-master,
     py32-1.6, py32-1.7, py32-master,
     py33-1.6, py33-1.7, py33-master,
-    py34-1.7, py34-master
+    py34-1.7, py34-master,
     pypypy-1.6, pypypy-1.7, pypypy-master,
 
 [testenv]


### PR DESCRIPTION
New option `CUSTOMER_REF_MODEL` lets you specify any arbitrary model to attach a `Customer` model to, not just the `User` model.
